### PR TITLE
Липсва bullsandcows.h

### DIFF
--- a/Алекс Николов (81094)/81094.cpp
+++ b/Алекс Николов (81094)/81094.cpp
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <cstring>
 #include "bullsandcows.h"
-
+//Този файл липсва в директорията
 using namespace std;
 
 BullsAndCows::BullsAndCows(int size)


### PR DESCRIPTION
В .cpp файла се реферира #include "bullsandcows.h", а реално него го няма в папката.

Тестов Потребител (ФН:12345)